### PR TITLE
feat: refactor FMI 3.0 traits and instance interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
+ "paste",
  "tempfile",
  "thiserror",
  "url",
@@ -1820,6 +1821,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"

--- a/fmi-sim/src/sim/fmi2/cs.rs
+++ b/fmi-sim/src/sim/fmi2/cs.rs
@@ -18,7 +18,7 @@ use crate::{
     Error,
 };
 
-impl<'a> SimStateTrait<'a, InstanceCS<'a>> for SimState<InstanceCS<'a>> {
+impl<'a> SimStateTrait<'a, InstanceCS<'a>, Fmi2Import> for SimState<InstanceCS<'a>> {
     fn new(
         import: &'a Fmi2Import,
         sim_params: SimParams,

--- a/fmi-sim/src/sim/fmi2/me.rs
+++ b/fmi-sim/src/sim/fmi2/me.rs
@@ -13,7 +13,7 @@ use crate::{
     Error,
 };
 
-impl<'a> SimStateTrait<'a, InstanceME<'a>> for SimState<InstanceME<'a>> {
+impl<'a> SimStateTrait<'a, InstanceME<'a>, Fmi2Import> for SimState<InstanceME<'a>> {
     fn new(
         import: &'a Fmi2Import,
         sim_params: SimParams,

--- a/fmi-sim/src/sim/fmi3/cs.rs
+++ b/fmi-sim/src/sim/fmi3/cs.rs
@@ -1,9 +1,6 @@
 use anyhow::Context;
 use fmi::{
-    fmi3::{
-        import::Fmi3Import,
-        instance::{CoSimulation, InstanceCS},
-    },
+    fmi3::{import::Fmi3Import, instance::InstanceCS, CoSimulation, Fmi3Model},
     traits::{FmiInstance, FmiStatus},
 };
 
@@ -17,7 +14,7 @@ use crate::{
     Error,
 };
 
-impl<'a> SimStateTrait<'a, InstanceCS<'a>> for SimState<InstanceCS<'a>> {
+impl<'a> SimStateTrait<'a, InstanceCS<'a>, Fmi3Import> for SimState<InstanceCS<'a>> {
     fn new(
         import: &'a Fmi3Import,
         sim_params: SimParams,

--- a/fmi-sim/src/sim/fmi3/me.rs
+++ b/fmi-sim/src/sim/fmi3/me.rs
@@ -1,11 +1,11 @@
-use fmi::fmi3::{import::Fmi3Import, instance::InstanceME};
+use fmi::fmi3::{import::Fmi3Import, instance::InstanceME, Fmi3Model};
 
 use crate::{
     sim::{params::SimParams, InputState, RecorderState, SimState, SimStateTrait},
     Error,
 };
 
-impl<'a> SimStateTrait<'a, InstanceME<'a>> for SimState<InstanceME<'a>> {
+impl<'a> SimStateTrait<'a, InstanceME<'a>, Fmi3Import> for SimState<InstanceME<'a>> {
     fn new(
         import: &'a Fmi3Import,
         sim_params: SimParams,

--- a/fmi-sim/src/sim/fmi3/mod.rs
+++ b/fmi-sim/src/sim/fmi3/mod.rs
@@ -1,7 +1,7 @@
 use arrow::array::RecordBatch;
 
 use fmi::{
-    fmi3::{import::Fmi3Import, instance::Common},
+    fmi3::{import::Fmi3Import, Common},
     traits::{FmiImport, FmiInstance, FmiStatus},
 };
 

--- a/fmi-sim/src/sim/io.rs
+++ b/fmi-sim/src/sim/io.rs
@@ -68,9 +68,8 @@ where
 impl<Inst> InputState<Inst>
 where
     Inst: FmiInstance,
-    Inst::Import: ImportSchemaBuilder,
 {
-    pub fn new(import: &Inst::Import, input_data: Option<RecordBatch>) -> anyhow::Result<Self> {
+    pub fn new<Import: ImportSchemaBuilder<ValueRef = Inst::ValueRef>>(import: &Import, input_data: Option<RecordBatch>) -> anyhow::Result<Self> {
         let model_input_schema = Arc::new(import.inputs_schema());
         let continuous_inputs = import.continuous_inputs().collect();
         let discrete_inputs = import.discrete_inputs().collect();
@@ -194,9 +193,8 @@ pub struct RecorderState<Inst: FmiInstance> {
 impl<Inst> RecorderState<Inst>
 where
     Inst: FmiInstance,
-    Inst::Import: ImportSchemaBuilder,
 {
-    pub fn new(import: &Inst::Import, sim_params: &SimParams) -> Self {
+    pub fn new<Import: ImportSchemaBuilder<ValueRef = Inst::ValueRef>>(import: &Import, sim_params: &SimParams) -> Self {
         let num_points = ((sim_params.stop_time - sim_params.start_time)
             / sim_params.output_interval)
             .ceil() as usize;

--- a/fmi-sim/src/sim/me.rs
+++ b/fmi-sim/src/sim/me.rs
@@ -7,14 +7,13 @@ use crate::Error;
 use super::{
     interpolation::Linear,
     solver::Solver,
-    traits::{ImportSchemaBuilder, InstRecordValues, InstSetValues, SimHandleEvents, SimMe},
+    traits::{InstRecordValues, InstSetValues, SimHandleEvents, SimMe},
     SimState, SimStats,
 };
 
 impl<Inst> SimMe<Inst> for SimState<Inst>
 where
     Inst: FmiInstance + FmiModelExchange + InstSetValues + InstRecordValues + FmiEventHandler,
-    Inst::Import: ImportSchemaBuilder,
 {
     fn main_loop<S>(&mut self, solver_params: S::Params) -> Result<SimStats, Error>
     where
@@ -29,7 +28,7 @@ where
         let nx = self.inst.get_number_of_continuous_state_values();
         let nz = self.inst.get_number_of_event_indicator_values();
 
-        let mut solver = S::new(
+        let mut solver = <S as Solver<Inst>>::new(
             self.sim_params.start_time,
             self.sim_params.tolerance.unwrap_or_default(),
             nx,

--- a/fmi-sim/src/sim/mod.rs
+++ b/fmi-sim/src/sim/mod.rs
@@ -1,7 +1,7 @@
 use arrow::array::RecordBatch;
 use std::path::Path;
 
-use fmi::traits::{FmiEventHandler, FmiInstance, FmiStatus};
+use fmi::traits::{FmiEventHandler, FmiImport, FmiInstance, FmiStatus};
 
 pub use io::{InputState, RecorderState};
 
@@ -36,9 +36,9 @@ where
     next_event_time: Option<f64>,
 }
 
-pub trait SimStateTrait<'a, Inst: FmiInstance> {
+pub trait SimStateTrait<'a, Inst: FmiInstance, Import: FmiImport> {
     fn new(
-        import: &'a Inst::Import,
+        import: &'a Import,
         sim_params: SimParams,
         input_state: InputState<Inst>,
         output_state: RecorderState<Inst>,

--- a/fmi/Cargo.toml
+++ b/fmi/Cargo.toml
@@ -36,6 +36,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 url = { version = "2.2", optional = true }
 zip = { workspace = true }
+paste = { version = "1.0" }
 
 [build-dependencies]
 built = "0.8"

--- a/fmi/src/fmi2/instance/mod.rs
+++ b/fmi/src/fmi2/instance/mod.rs
@@ -55,7 +55,6 @@ impl<'a, Tag> Drop for Instance<'a, Tag> {
 
 impl<'a, Tag> FmiInstance for Instance<'a, Tag> {
     type ModelDescription = schema::Fmi2ModelDescription;
-    type Import = Fmi2Import;
     type ValueRef = <Fmi2Import as FmiImport>::ValueRef;
     type Status = Fmi2Status;
 

--- a/fmi/src/fmi3/import.rs
+++ b/fmi/src/fmi3/import.rs
@@ -3,12 +3,10 @@ use std::{path::PathBuf, str::FromStr};
 use fmi_schema::MajorVersion;
 use tempfile::TempDir;
 
-use crate::{traits::FmiImport, Error};
-
-use super::{
-    binding,
-    instance::{Instance, CS, ME},
-    schema,
+use crate::{
+    fmi3::{binding, instance, schema, Fmi3Model},
+    traits::FmiImport,
+    Error,
 };
 
 /// FMU import for FMI 3.0
@@ -87,7 +85,11 @@ impl FmiImport for Fmi3Import {
     }
 }
 
-impl Fmi3Import {
+impl<'a> Fmi3Model<'a> for Fmi3Import {
+    type InstanceCS = instance::InstanceCS<'a>;
+    type InstanceME = instance::InstanceME<'a>;
+    type InstanceSE = instance::InstanceSE<'a>;
+
     /// Build a derived model description from the raw-schema model description
     #[cfg(false)]
     pub fn model(&self) -> &model::ModelDescription {
@@ -97,28 +99,28 @@ impl Fmi3Import {
     /// Create a new instance of the FMU for Model-Exchange
     ///
     /// See [`Instance::<ME>::new()`] for more information.
-    pub fn instantiate_me(
-        &self,
+    fn instantiate_me(
+        &'a self,
         instance_name: &str,
         visible: bool,
         logging_on: bool,
-    ) -> Result<Instance<'_, ME>, Error> {
-        Instance::<'_, ME>::new(self, instance_name, visible, logging_on)
+    ) -> Result<Self::InstanceME, Error> {
+        instance::InstanceME::new(self, instance_name, visible, logging_on)
     }
 
     /// Create a new instance of the FMU for Co-Simulation
     ///
     /// See [`Instance::<CS>::new()`] for more information.
-    pub fn instantiate_cs(
-        &self,
+    fn instantiate_cs(
+        &'a self,
         instance_name: &str,
         visible: bool,
         logging_on: bool,
         event_mode_used: bool,
         early_return_allowed: bool,
         required_intermediate_variables: &[binding::fmi3ValueReference],
-    ) -> Result<Instance<'_, CS>, Error> {
-        Instance::<'_, CS>::new(
+    ) -> Result<Self::InstanceCS, Error> {
+        instance::InstanceCS::new(
             self,
             instance_name,
             visible,
@@ -127,5 +129,17 @@ impl Fmi3Import {
             early_return_allowed,
             required_intermediate_variables,
         )
+    }
+
+    /// Create a new instance of the FMU for Scheduled Execution
+    ///
+    /// See [`Instance::<SE>::new()`] for more information.
+    fn instantiate_se(
+        &'a self,
+        instance_name: &str,
+        visible: bool,
+        logging_on: bool,
+    ) -> Result<Self::InstanceSE, Error> {
+        instance::InstanceSE::new(self, instance_name, visible, logging_on)
     }
 }

--- a/fmi/src/fmi3/instance/co_simulation.rs
+++ b/fmi/src/fmi3/instance/co_simulation.rs
@@ -1,12 +1,12 @@
 use std::ffi::CString;
 
 use crate::{
-    fmi3::{binding, import, logger, Fmi3Status},
+    fmi3::{binding, import, logger, CoSimulation, Common, Fmi3Status},
     traits::{FmiEventHandler, FmiImport},
     Error,
 };
 
-use super::{CoSimulation, Common, Instance, CS};
+use super::{Instance, CS};
 
 impl<'a> Instance<'a, CS> {
     /// Returns a new CoSimulation instance.

--- a/fmi/src/fmi3/instance/common.rs
+++ b/fmi/src/fmi3/instance/common.rs
@@ -1,11 +1,15 @@
 use std::mem::MaybeUninit;
 
 use crate::{
-    fmi3::{binding, Fmi3Status},
-    traits::FmiStatus,
+    fmi3::{
+        binding,
+        import::Fmi3Import,
+        instance::Instance,
+        traits::{Common, GetSet},
+        Fmi3Error, Fmi3Status,
+    },
+    traits::{FmiImport, FmiStatus},
 };
-
-use super::{Common, Instance};
 
 macro_rules! impl_getter_setter {
     ($ty:ty, $get:ident, $set:ident, $fmi_get:ident, $fmi_set:ident) => {
@@ -35,6 +39,270 @@ macro_rules! impl_getter_setter {
             .into()
         }
     };
+}
+
+impl<'a, Tag> GetSet for Instance<'a, Tag> {
+    type ValueRef = <Fmi3Import as FmiImport>::ValueRef;
+    impl_getter_setter!(
+        bool,
+        get_boolean,
+        set_boolean,
+        fmi3GetBoolean,
+        fmi3SetBoolean
+    );
+    impl_getter_setter!(
+        f32,
+        get_float32,
+        set_float32,
+        fmi3GetFloat32,
+        fmi3SetFloat32
+    );
+    impl_getter_setter!(
+        f64,
+        get_float64,
+        set_float64,
+        fmi3GetFloat64,
+        fmi3SetFloat64
+    );
+    impl_getter_setter!(i8, get_int8, set_int8, fmi3GetInt8, fmi3SetInt8);
+    impl_getter_setter!(i16, get_int16, set_int16, fmi3GetInt16, fmi3SetInt16);
+    impl_getter_setter!(i32, get_int32, set_int32, fmi3GetInt32, fmi3SetInt32);
+    impl_getter_setter!(i64, get_int64, set_int64, fmi3GetInt64, fmi3SetInt64);
+    impl_getter_setter!(u8, get_uint8, set_uint8, fmi3GetUInt8, fmi3SetUInt8);
+    impl_getter_setter!(u16, get_uint16, set_uint16, fmi3GetUInt16, fmi3SetUInt16);
+    impl_getter_setter!(u32, get_uint32, set_uint32, fmi3GetUInt32, fmi3SetUInt32);
+    impl_getter_setter!(u64, get_uint64, set_uint64, fmi3GetUInt64, fmi3SetUInt64);
+
+    fn get_string(
+        &mut self,
+        vrs: &[Self::ValueRef],
+        values: &mut [std::ffi::CString],
+    ) -> Result<(), Fmi3Error> {
+        let n_values = values.len();
+
+        const STACK_THRESHOLD: usize = 32;
+
+        if n_values <= STACK_THRESHOLD {
+            // Stack-allocated array for small cases
+            let mut stack_ptrs: [MaybeUninit<*const binding::fmi3Char>; STACK_THRESHOLD] =
+                unsafe { MaybeUninit::uninit().assume_init() };
+
+            Fmi3Status::from(unsafe {
+                self.binding.fmi3GetString(
+                    self.ptr,
+                    vrs.as_ptr(),
+                    vrs.len() as _,
+                    stack_ptrs.as_mut_ptr() as *mut binding::fmi3String,
+                    n_values,
+                )
+            })
+            .ok()?;
+
+            // Copy the C strings into the output CString values
+            for (i, value) in values.iter_mut().enumerate() {
+                let ptr = unsafe { stack_ptrs[i].assume_init() };
+                if ptr.is_null() {
+                    return Err(Fmi3Error::Error);
+                }
+                let cstr = unsafe { std::ffi::CStr::from_ptr(ptr) };
+                // Copy the string data into the provided CString
+                *value = std::ffi::CString::new(cstr.to_bytes()).map_err(|_| Fmi3Error::Error)?;
+            }
+        } else {
+            // Heap allocation for large arrays
+            let mut value_ptrs: Vec<*const binding::fmi3Char> = vec![std::ptr::null(); n_values];
+
+            Fmi3Status::from(unsafe {
+                self.binding.fmi3GetString(
+                    self.ptr,
+                    vrs.as_ptr(),
+                    vrs.len(),
+                    value_ptrs.as_mut_ptr(),
+                    n_values,
+                )
+            })
+            .ok()?;
+
+            // Copy the C strings into the output CString values
+            for (value, ptr) in values.iter_mut().zip(value_ptrs.iter()) {
+                if ptr.is_null() {
+                    return Err(Fmi3Error::Error);
+                }
+                let cstr = unsafe { std::ffi::CStr::from_ptr(*ptr) };
+                // Copy the string data into the provided CString
+                *value = std::ffi::CString::new(cstr.to_bytes()).map_err(|_| Fmi3Error::Error)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn set_string(
+        &mut self,
+        vrs: &[Self::ValueRef],
+        values: &[std::ffi::CString],
+    ) -> Result<(), Fmi3Error> {
+        let n_values = values.len();
+
+        const STACK_THRESHOLD: usize = 32;
+
+        if n_values <= STACK_THRESHOLD {
+            // Stack-allocated array for small cases
+            let mut stack_ptrs: [MaybeUninit<*const binding::fmi3Char>; STACK_THRESHOLD] =
+                unsafe { MaybeUninit::uninit().assume_init() };
+
+            for (i, value) in values.iter().enumerate() {
+                stack_ptrs[i] = MaybeUninit::new(value.as_ptr());
+            }
+
+            Fmi3Status::from(unsafe {
+                self.binding.fmi3SetString(
+                    self.ptr,
+                    vrs.as_ptr(),
+                    vrs.len() as _,
+                    stack_ptrs.as_mut_ptr() as *const binding::fmi3String,
+                    n_values,
+                )
+            })
+            .ok()?;
+        } else {
+            // Heap allocation for large arrays
+            let value_ptrs: Vec<*const binding::fmi3Char> =
+                values.iter().map(|value| value.as_ptr()).collect();
+
+            Fmi3Status::from(unsafe {
+                self.binding.fmi3SetString(
+                    self.ptr,
+                    vrs.as_ptr(),
+                    vrs.len() as _,
+                    value_ptrs.as_ptr(),
+                    n_values,
+                )
+            })
+            .ok()?;
+        }
+
+        Ok(())
+    }
+
+    fn get_binary(
+        &mut self,
+        value_references: &[binding::fmi3ValueReference],
+        value_buffers: &mut [&mut [u8]],
+    ) -> Result<Vec<usize>, Fmi3Error> {
+        let n_value_references = value_references.len();
+        let n_values = value_buffers.len();
+
+        let mut value_sizes = vec![0usize; n_values];
+
+        // Use stack allocation for small arrays, heap for large ones
+        const STACK_THRESHOLD: usize = 32;
+
+        // Helper function to copy data from FMU pointers to user buffers
+        let copy_binary_data = |value_ptrs: &[*const u8],
+                                value_sizes: &[usize],
+                                value_buffers: &mut [&mut [u8]]|
+         -> Result<(), Fmi3Error> {
+            for (i, value_buffer) in value_buffers.iter_mut().enumerate() {
+                let fmu_ptr = value_ptrs[i];
+                let fmu_size = value_sizes[i];
+
+                if fmu_ptr.is_null() {
+                    log::error!("FMU returned null pointer for binary value {}", i);
+                    return Err(Fmi3Error::Error);
+                }
+
+                if value_buffer.len() < fmu_size {
+                    log::error!(
+                        "User buffer too small for binary value {}: buffer size = {}, required size = {}",
+                        i, value_buffer.len(), fmu_size
+                    );
+                    return Err(Fmi3Error::Error);
+                }
+
+                // Copy the data from FMU buffer to user buffer
+                unsafe {
+                    std::ptr::copy_nonoverlapping(fmu_ptr, value_buffer.as_mut_ptr(), fmu_size);
+                }
+            }
+            Ok(())
+        };
+
+        if n_values <= STACK_THRESHOLD {
+            // Stack-allocated array for small cases
+            let mut stack_ptrs: [MaybeUninit<*const u8>; STACK_THRESHOLD] =
+                [const { MaybeUninit::uninit() }; STACK_THRESHOLD];
+
+            // Initialize pointers to null for the FMU to populate
+            for ptr in stack_ptrs.iter_mut() {
+                *ptr = MaybeUninit::new(std::ptr::null());
+            }
+
+            Fmi3Status::from(unsafe {
+                self.binding.fmi3GetBinary(
+                    self.ptr,
+                    value_references.as_ptr(),
+                    n_value_references,
+                    value_sizes.as_mut_ptr(),
+                    stack_ptrs.as_mut_ptr() as *mut *const u8,
+                    n_values,
+                )
+            })
+            .ok()?;
+
+            // Convert stack pointers to slice for copy function
+            let ptr_slice: Vec<*const u8> = (0..n_values)
+                .map(|i| unsafe { stack_ptrs[i].assume_init() })
+                .collect();
+
+            copy_binary_data(&ptr_slice, &value_sizes, value_buffers)?;
+        } else {
+            // Heap allocation for large arrays
+            let mut value_ptrs: Vec<*const u8> = vec![std::ptr::null(); n_values];
+
+            Fmi3Status::from(unsafe {
+                self.binding.fmi3GetBinary(
+                    self.ptr,
+                    value_references.as_ptr(),
+                    n_value_references,
+                    value_sizes.as_mut_ptr(),
+                    value_ptrs.as_mut_ptr(),
+                    n_values,
+                )
+            })
+            .ok()?;
+
+            copy_binary_data(&value_ptrs, &value_sizes, value_buffers)?;
+        }
+
+        Ok(value_sizes)
+    }
+
+    fn set_binary(
+        &mut self,
+        vrs: &[binding::fmi3ValueReference],
+        values: &[&[u8]],
+    ) -> Result<(), Fmi3Error> {
+        let n_value_references = vrs.len();
+        let n_values = values.len();
+
+        let value_sizes: Vec<usize> = values.iter().map(|v| v.len()).collect();
+        let value_ptrs: Vec<*const u8> = values.iter().map(|v| v.as_ptr()).collect();
+
+        Fmi3Status::from(unsafe {
+            self.binding.fmi3SetBinary(
+                self.ptr,
+                vrs.as_ptr(),
+                n_value_references,
+                value_sizes.as_ptr(),
+                value_ptrs.as_ptr() as *const binding::fmi3Binary,
+                n_values,
+            )
+        })
+        .ok()?;
+
+        Ok(())
+    }
 }
 
 impl<'a, Tag> Common for Instance<'a, Tag> {
@@ -107,147 +375,6 @@ impl<'a, Tag> Common for Instance<'a, Tag> {
 
     fn reset(&mut self) -> Fmi3Status {
         unsafe { self.binding.fmi3Reset(self.ptr) }.into()
-    }
-
-    impl_getter_setter!(
-        bool,
-        get_boolean,
-        set_boolean,
-        fmi3GetBoolean,
-        fmi3SetBoolean
-    );
-    impl_getter_setter!(
-        f32,
-        get_float32,
-        set_float32,
-        fmi3GetFloat32,
-        fmi3SetFloat32
-    );
-    impl_getter_setter!(
-        f64,
-        get_float64,
-        set_float64,
-        fmi3GetFloat64,
-        fmi3SetFloat64
-    );
-    impl_getter_setter!(i8, get_int8, set_int8, fmi3GetInt8, fmi3SetInt8);
-    impl_getter_setter!(i16, get_int16, set_int16, fmi3GetInt16, fmi3SetInt16);
-    impl_getter_setter!(i32, get_int32, set_int32, fmi3GetInt32, fmi3SetInt32);
-    impl_getter_setter!(i64, get_int64, set_int64, fmi3GetInt64, fmi3SetInt64);
-    impl_getter_setter!(u8, get_uint8, set_uint8, fmi3GetUInt8, fmi3SetUInt8);
-    impl_getter_setter!(u16, get_uint16, set_uint16, fmi3GetUInt16, fmi3SetUInt16);
-    impl_getter_setter!(u32, get_uint32, set_uint32, fmi3GetUInt32, fmi3SetUInt32);
-    impl_getter_setter!(u64, get_uint64, set_uint64, fmi3GetUInt64, fmi3SetUInt64);
-
-    fn get_string(
-        &mut self,
-        vrs: &[binding::fmi3ValueReference],
-        values: &mut [String],
-    ) -> Fmi3Status {
-        unsafe {
-            // Create a mutable vec of fmi3String with uninitialized values to pass to ffi
-            let mut ret_values = MaybeUninit::<Vec<binding::fmi3String>>::uninit();
-            let stat = self.binding.fmi3GetString(
-                self.ptr,
-                vrs.as_ptr(),
-                vrs.len() as _,
-                ret_values.assume_init_mut().as_mut_ptr(),
-                ret_values.assume_init_ref().len() as _,
-            );
-            for (v, ret) in ret_values.assume_init_ref().iter().zip(values.iter_mut()) {
-                *ret = std::ffi::CStr::from_ptr(*v)
-                    .to_str()
-                    .expect("Error converting C string")
-                    .to_string();
-            }
-            stat
-        }
-        .into()
-    }
-
-    fn set_string<'b>(
-        &mut self,
-        vrs: &[binding::fmi3ValueReference],
-        values: impl Iterator<Item = &'b str>,
-    ) -> Fmi3Status {
-        let values = values
-            .map(|s| std::ffi::CString::new(s.as_bytes()).expect("Error building CString"))
-            .collect::<Vec<_>>();
-
-        let ptrs = values
-            .iter()
-            .map(|s| s.as_c_str().as_ptr())
-            .collect::<Vec<_>>();
-
-        unsafe {
-            self.binding.fmi3SetString(
-                self.ptr,
-                vrs.as_ptr(),
-                vrs.len() as _,
-                ptrs.as_ptr(),
-                values.len() as _,
-            )
-        }
-        .into()
-    }
-
-    fn get_binary(
-        &mut self,
-        vrs: &[binding::fmi3ValueReference],
-        values: &mut [Vec<u8>],
-    ) -> Fmi3Status {
-        assert_eq!(vrs.len(), values.len());
-        let mut value_sizes = vec![0; values.len()];
-        let mut value_ptrs = unsafe {
-            // Safety: `MaybeUninit` is guaranteed to be initialized by `fmi3GetBinary`
-            vec![MaybeUninit::<binding::fmi3Binary>::zeroed().assume_init(); values.len()]
-        };
-
-        let status: Fmi3Status = unsafe {
-            self.binding.fmi3GetBinary(
-                self.ptr,
-                vrs.as_ptr(),
-                vrs.len() as _,
-                value_sizes.as_mut_ptr(),
-                value_ptrs.as_mut_ptr(),
-                values.len() as _,
-            )
-        }
-        .into();
-
-        if status.is_error() {
-            return status;
-        }
-
-        unsafe {
-            // Copy the binary data into `values`
-            // Safety: `value_sizes` and `value_ptrs` are guaranteed to be initialized by
-            // `fmi3GetBinary`
-            for (i, (size, ptr)) in value_sizes.iter().zip(value_ptrs.iter()).enumerate() {
-                values[i] = std::slice::from_raw_parts(*ptr, *size).to_vec();
-            }
-        }
-        status
-    }
-
-    fn set_binary<'b>(
-        &mut self,
-        vrs: &[binding::fmi3ValueReference],
-        values: impl Iterator<Item = &'b [u8]>,
-    ) -> Fmi3Status {
-        let values = values.collect::<Vec<_>>();
-        let value_sizes = values.iter().map(|v| v.len()).collect::<Vec<_>>();
-        unsafe {
-            self.binding.fmi3SetBinary(
-                self.ptr,
-                vrs.as_ptr(),
-                vrs.len() as _,
-                value_sizes.as_ptr(),
-                values.as_ptr() as *const binding::fmi3Binary,
-                values.len() as _,
-            )
-        }
-        .into()
     }
 
     #[cfg(false)]

--- a/fmi/src/fmi3/instance/model_exchange.rs
+++ b/fmi/src/fmi3/instance/model_exchange.rs
@@ -1,12 +1,12 @@
 use std::ffi::CString;
 
 use crate::{
-    fmi3::{binding, import, logger},
+    fmi3::{binding, import, logger, Common, Fmi3Status, ModelExchange},
     traits::{FmiEventHandler, FmiImport, FmiModelExchange},
     Error,
 };
 
-use super::{traits::ModelExchange, Common, Instance, ME};
+use super::{Instance, ME};
 
 impl<'a> Instance<'a, ME> {
     pub fn new(
@@ -66,7 +66,7 @@ impl<'a> Instance<'a, ME> {
 impl ModelExchange for Instance<'_, ME> {
     /// This function must be called to change from Event Mode into Continuous-Time Mode in Model
     /// Exchange.
-    fn enter_continuous_time_mode(&mut self) -> Self::Status {
+    fn enter_continuous_time_mode(&mut self) -> Fmi3Status {
         unsafe { self.binding.fmi3EnterContinuousTimeMode(self.ptr) }.into()
     }
 
@@ -75,7 +75,7 @@ impl ModelExchange for Instance<'_, ME> {
         no_set_fmu_state_prior: bool,
         enter_event_mode: &mut bool,
         terminate_simulation: &mut bool,
-    ) -> Self::Status {
+    ) -> Fmi3Status {
         unsafe {
             self.binding.fmi3CompletedIntegratorStep(
                 self.ptr,
@@ -87,11 +87,11 @@ impl ModelExchange for Instance<'_, ME> {
         .into()
     }
 
-    fn set_time(&mut self, time: f64) -> Self::Status {
+    fn set_time(&mut self, time: f64) -> Fmi3Status {
         unsafe { self.binding.fmi3SetTime(self.ptr, time) }.into()
     }
 
-    fn get_continuous_states(&mut self, continuous_states: &mut [f64]) -> Self::Status {
+    fn get_continuous_states(&mut self, continuous_states: &mut [f64]) -> Fmi3Status {
         unsafe {
             self.binding.fmi3GetContinuousStates(
                 self.ptr,
@@ -102,7 +102,7 @@ impl ModelExchange for Instance<'_, ME> {
         .into()
     }
 
-    fn set_continuous_states(&mut self, states: &[f64]) -> Self::Status {
+    fn set_continuous_states(&mut self, states: &[f64]) -> Fmi3Status {
         unsafe {
             self.binding
                 .fmi3SetContinuousStates(self.ptr, states.as_ptr(), states.len())
@@ -110,7 +110,7 @@ impl ModelExchange for Instance<'_, ME> {
         .into()
     }
 
-    fn get_continuous_state_derivatives(&mut self, derivatives: &mut [f64]) -> Self::Status {
+    fn get_continuous_state_derivatives(&mut self, derivatives: &mut [f64]) -> Fmi3Status {
         unsafe {
             self.binding.fmi3GetContinuousStateDerivatives(
                 self.ptr,
@@ -121,7 +121,7 @@ impl ModelExchange for Instance<'_, ME> {
         .into()
     }
 
-    fn get_nominals_of_continuous_states(&mut self, nominals: &mut [f64]) -> Self::Status {
+    fn get_nominals_of_continuous_states(&mut self, nominals: &mut [f64]) -> Fmi3Status {
         unsafe {
             self.binding.fmi3GetNominalsOfContinuousStates(
                 self.ptr,
@@ -132,7 +132,7 @@ impl ModelExchange for Instance<'_, ME> {
         .into()
     }
 
-    fn get_event_indicators(&mut self, event_indicators: &mut [f64]) -> Self::Status {
+    fn get_event_indicators(&mut self, event_indicators: &mut [f64]) -> Fmi3Status {
         unsafe {
             self.binding.fmi3GetEventIndicators(
                 self.ptr,
@@ -143,10 +143,7 @@ impl ModelExchange for Instance<'_, ME> {
         .into()
     }
 
-    fn get_number_of_event_indicators(
-        &self,
-        number_of_event_indicators: &mut usize,
-    ) -> Self::Status {
+    fn get_number_of_event_indicators(&self, number_of_event_indicators: &mut usize) -> Fmi3Status {
         unsafe {
             self.binding
                 .fmi3GetNumberOfEventIndicators(self.ptr, number_of_event_indicators)

--- a/fmi/src/fmi3/instance/scheduled_execution.rs
+++ b/fmi/src/fmi3/instance/scheduled_execution.rs
@@ -1,12 +1,12 @@
 use std::ffi::CString;
 
 use crate::{
-    fmi3::{binding, import, logger},
+    fmi3::{binding, import, logger, ScheduledExecution},
     traits::FmiImport,
     Error,
 };
 
-use super::{Instance, ScheduledExecution, SE};
+use super::{Instance, SE};
 
 unsafe extern "C" fn clock_update(_instance_environment: binding::fmi3InstanceEnvironment) {
     todo!();

--- a/fmi/src/fmi3/traits.rs
+++ b/fmi/src/fmi3/traits.rs
@@ -1,11 +1,97 @@
 //! Traits for the different instance types.
 
-use crate::traits::FmiInstance;
+use crate::{fmi3::Fmi3Error, Error};
 
-use super::Fmi3Status;
+use super::{binding, Fmi3Status};
 
-/// Interface common to all instance types
-pub trait Common: FmiInstance {
+macro_rules! default_getter_setter {
+    ($name:ident, $ty:ty) => {
+        paste::paste! {
+            /// Get the values of the specified variable references.
+            ///
+            /// See [https://fmi-standard.org/docs/3.0.1/#get-and-set-variable-values]
+            fn [<get_ $name>](&mut self, _vrs: &[Self::ValueRef], _values: &mut [$ty]) -> Fmi3Status {
+                unimplemented!();
+            }
+            /// Set the values of the specified variable references.
+            ///
+            /// See [https://fmi-standard.org/docs/3.0.1/#get-and-set-variable-values]
+            fn [<set_ $name>](&mut self, _vrs: &[Self::ValueRef], _values: &[$ty]) -> Fmi3Status {
+                unimplemented!();
+            }
+        }
+    };
+}
+
+/// FMI Getter / Setter interface
+pub trait GetSet {
+    type ValueRef: Copy + From<binding::fmi3ValueReference> + Into<binding::fmi3ValueReference>;
+
+    default_getter_setter!(boolean, bool);
+    default_getter_setter!(float32, f32);
+    default_getter_setter!(float64, f64);
+    default_getter_setter!(int8, i8);
+    default_getter_setter!(int16, i16);
+    default_getter_setter!(int32, i32);
+    default_getter_setter!(int64, i64);
+    default_getter_setter!(uint8, u8);
+    default_getter_setter!(uint16, u16);
+    default_getter_setter!(uint32, u32);
+    default_getter_setter!(uint64, u64);
+    fn get_string(
+        &mut self,
+        _vrs: &[Self::ValueRef],
+        _values: &mut [std::ffi::CString],
+    ) -> Result<(), Fmi3Error> {
+        unimplemented!();
+    }
+
+    fn set_string(
+        &mut self,
+        _vrs: &[Self::ValueRef],
+        _values: &[std::ffi::CString],
+    ) -> Result<(), Fmi3Error> {
+        unimplemented!();
+    }
+
+    /// Get binary values from the FMU.
+    ///
+    /// The FMU provides pointers to its internal binary data, which we copy into the
+    /// user-provided buffers. If any user buffer is too small for the corresponding
+    /// binary data, an error is returned.
+    ///
+    /// Returns the actual sizes of the binary data that was copied.
+    ///
+    /// See [https://fmi-standard.org/docs/3.0.1/#get-and-set-variable-values]
+    fn get_binary(
+        &mut self,
+        _vrs: &[Self::ValueRef],
+        _values: &mut [&mut [u8]],
+    ) -> Result<Vec<usize>, Fmi3Error> {
+        unimplemented!()
+    }
+
+    /// Set binary values in the FMU.
+    ///
+    /// See [https://fmi-standard.org/docs/3.0.1/#get-and-set-variable-values]
+    fn set_binary(&mut self, _vrs: &[Self::ValueRef], _values: &[&[u8]]) -> Result<(), Fmi3Error> {
+        unimplemented!()
+    }
+
+    /// See [https://fmi-standard.org/docs/3.0.1/#fmi3GetFMUState]
+    #[cfg(false)]
+    fn get_fmu_state<Tag>(
+        &mut self,
+        state: Option<Fmu3State<'_, Tag>>,
+    ) -> Result<Fmu3State<'_, Tag>, Error>;
+
+    /// See [https://fmi-standard.org/docs/3.0.1/#fmi3SetFMUState]
+    #[cfg(false)]
+    fn set_fmu_state<Tag>(&mut self, state: &Fmu3State<'_, Tag>) -> Fmi3Status;
+}
+
+/// Interface common to all FMI3 instance types
+pub trait Common: GetSet {
     /// The FMI-standard version string
     fn get_version(&self) -> &str;
 
@@ -81,54 +167,6 @@ pub trait Common: FmiInstance {
     /// See [https://fmi-standard.org/docs/3.0.1/#fmi3Reset]
     fn reset(&mut self) -> Fmi3Status;
 
-    /// See [https://fmi-standard.org/docs/3.0.1/#get-and-set-variable-values]
-    fn get_boolean(&mut self, vrs: &[Self::ValueRef], values: &mut [bool]) -> Fmi3Status;
-    fn get_float32(&mut self, vrs: &[Self::ValueRef], values: &mut [f32]) -> Fmi3Status;
-    fn get_float64(&mut self, vrs: &[Self::ValueRef], values: &mut [f64]) -> Fmi3Status;
-    fn get_int8(&mut self, vrs: &[Self::ValueRef], values: &mut [i8]) -> Fmi3Status;
-    fn get_int16(&mut self, vrs: &[Self::ValueRef], values: &mut [i16]) -> Fmi3Status;
-    fn get_int32(&mut self, vrs: &[Self::ValueRef], values: &mut [i32]) -> Fmi3Status;
-    fn get_int64(&mut self, vrs: &[Self::ValueRef], values: &mut [i64]) -> Fmi3Status;
-    fn get_uint8(&mut self, vrs: &[Self::ValueRef], values: &mut [u8]) -> Fmi3Status;
-    fn get_uint16(&mut self, vrs: &[Self::ValueRef], values: &mut [u16]) -> Fmi3Status;
-    fn get_uint32(&mut self, vrs: &[Self::ValueRef], values: &mut [u32]) -> Fmi3Status;
-    fn get_uint64(&mut self, vrs: &[Self::ValueRef], values: &mut [u64]) -> Fmi3Status;
-    fn get_string(&mut self, vrs: &[Self::ValueRef], values: &mut [String]) -> Fmi3Status;
-    fn get_binary(&mut self, vrs: &[Self::ValueRef], values: &mut [Vec<u8>]) -> Fmi3Status;
-
-    fn set_boolean(&mut self, vrs: &[Self::ValueRef], values: &[bool]) -> Fmi3Status;
-    fn set_float32(&mut self, vrs: &[Self::ValueRef], values: &[f32]) -> Fmi3Status;
-    fn set_float64(&mut self, vrs: &[Self::ValueRef], values: &[f64]) -> Fmi3Status;
-    fn set_int8(&mut self, vrs: &[Self::ValueRef], values: &[i8]) -> Fmi3Status;
-    fn set_int16(&mut self, vrs: &[Self::ValueRef], values: &[i16]) -> Fmi3Status;
-    fn set_int32(&mut self, vrs: &[Self::ValueRef], values: &[i32]) -> Fmi3Status;
-    fn set_int64(&mut self, vrs: &[Self::ValueRef], values: &[i64]) -> Fmi3Status;
-    fn set_uint8(&mut self, vrs: &[Self::ValueRef], values: &[u8]) -> Fmi3Status;
-    fn set_uint16(&mut self, vrs: &[Self::ValueRef], values: &[u16]) -> Fmi3Status;
-    fn set_uint32(&mut self, vrs: &[Self::ValueRef], values: &[u32]) -> Fmi3Status;
-    fn set_uint64(&mut self, vrs: &[Self::ValueRef], values: &[u64]) -> Fmi3Status;
-    fn set_string<'b>(
-        &mut self,
-        vrs: &[Self::ValueRef],
-        values: impl Iterator<Item = &'b str>,
-    ) -> Fmi3Status;
-    fn set_binary<'b>(
-        &mut self,
-        vrs: &[Self::ValueRef],
-        values: impl Iterator<Item = &'b [u8]>,
-    ) -> Fmi3Status;
-
-    /// See [https://fmi-standard.org/docs/3.0.1/#fmi3GetFMUState]
-    #[cfg(false)]
-    fn get_fmu_state<Tag>(
-        &mut self,
-        state: Option<Fmu3State<'_, Tag>>,
-    ) -> Result<Fmu3State<'_, Tag>, Error>;
-
-    /// See [https://fmi-standard.org/docs/3.0.1/#fmi3SetFMUState]
-    #[cfg(false)]
-    fn set_fmu_state<Tag>(&mut self, state: &Fmu3State<'_, Tag>) -> Fmi3Status;
-
     /// This function is called to signal a converged solution at the current super-dense time
     /// instant. `update_discrete_states` must be called at least once per super-dense time
     /// instant.
@@ -136,12 +174,14 @@ pub trait Common: FmiInstance {
     /// See [https://fmi-standard.org/docs/3.0.1/#fmi3UpdateDiscreteStates]
     fn update_discrete_states(
         &mut self,
-        discrete_states_need_update: &mut bool,
-        terminate_simulation: &mut bool,
-        nominals_of_continuous_states_changed: &mut bool,
-        values_of_continuous_states_changed: &mut bool,
-        next_event_time: &mut Option<f64>,
-    ) -> Fmi3Status;
+        _discrete_states_need_update: &mut bool,
+        _terminate_simulation: &mut bool,
+        _nominals_of_continuous_states_changed: &mut bool,
+        _values_of_continuous_states_changed: &mut bool,
+        _next_event_time: &mut Option<f64>,
+    ) -> Fmi3Status {
+        unimplemented!()
+    }
 }
 
 /// Interface for Model Exchange instances
@@ -169,7 +209,7 @@ pub trait ModelExchange: Common {
         no_set_fmu_state_prior: bool,
         enter_event_mode: &mut bool,
         terminate_simulation: &mut bool,
-    ) -> Self::Status;
+    ) -> Fmi3Status;
 
     /// Set a new value for the independent variable (typically a time instant).
     ///
@@ -292,4 +332,56 @@ pub trait ScheduledExecution: Common {
         clock_reference: Self::ValueRef,
         activation_time: f64,
     ) -> Fmi3Status;
+}
+
+/// Fmi3Model trait for types that support instantiating instances.
+pub trait Fmi3Model<'a> {
+    type InstanceME: ModelExchange;
+    type InstanceCS: CoSimulation;
+    type InstanceSE: ScheduledExecution;
+
+    /// Create a new instance of the FMU for Model-Exchange
+    ///
+    /// See [`Instance::<ME>::new()`] for more information.
+    fn instantiate_me(
+        &'a self,
+        _instance_name: &str,
+        _visible: bool,
+        _logging_on: bool,
+    ) -> Result<Self::InstanceME, Error> {
+        Err(Error::UnsupportedInterface(
+            "Model-Exchange is not supported".to_string(),
+        ))
+    }
+
+    /// Create a new instance of the FMU for Co-Simulation
+    ///
+    /// See [`Instance::<CS>::new()`] for more information.
+    fn instantiate_cs(
+        &'a self,
+        _instance_name: &str,
+        _visible: bool,
+        _logging_on: bool,
+        _event_mode_used: bool,
+        _early_return_allowed: bool,
+        _required_intermediate_variables: &[binding::fmi3ValueReference],
+    ) -> Result<Self::InstanceCS, Error> {
+        Err(Error::UnsupportedInterface(
+            "Co-Simulation is not supported".to_string(),
+        ))
+    }
+
+    /// Create a new instance of the FMU for Scheduled Execution
+    ///
+    /// See [`Instance::<SE>::new()`] for more information.
+    fn instantiate_se(
+        &'a self,
+        _instance_name: &str,
+        _visible: bool,
+        _logging_on: bool,
+    ) -> Result<Self::InstanceSE, Error> {
+        Err(Error::UnsupportedInterface(
+            "Scheduled Execution is not supported".to_string(),
+        ))
+    }
 }

--- a/fmi/src/traits.rs
+++ b/fmi/src/traits.rs
@@ -56,7 +56,6 @@ pub trait FmiStatus {
 /// Generic FMI instance trait
 pub trait FmiInstance {
     type ModelDescription: FmiModelDescription + DefaultExperiment;
-    type Import: FmiImport<ModelDescription = Self::ModelDescription, ValueRef = Self::ValueRef>;
     type ValueRef: Copy + From<u32> + Into<u32>;
     type Status: FmiStatus;
 

--- a/tests/test_imports.rs
+++ b/tests/test_imports.rs
@@ -1,4 +1,7 @@
-use fmi::traits::{FmiImport, FmiInstance as _};
+use fmi::{
+    fmi3::Fmi3Model,
+    traits::{FmiImport, FmiInstance as _},
+};
 use fmi_test_data::ReferenceFmus;
 
 extern crate fmi;


### PR DESCRIPTION
- Updated the `Fmi3Model` trait to include methods for instantiating instances for Model-Exchange, Co-Simulation, and Scheduled Execution.
- Introduced a new `traits` module for FMI 3.0, defining interfaces for `Common`, `ModelExchange`, `CoSimulation`, and `ScheduledExecution`.
- Removed unnecessary `Import` type from `FmiInstance` trait.
- Adjusted various methods to use the new trait structure and improved type handling.
- Disabled feature flags for certain methods and tests to streamline the codebase.
- Enhanced the `Fmi3Status` implementation with display formatting and conversion traits.
- Cleaned up imports and organized code for better readability and maintainability.
- Extract `GetSet` trait from `Common`.
- Rework string and binary interfaces.