### PR TITLE
fix(fmi-schema): allow optional event indicators for cs

### DIFF
--- a/fmi-schema/src/fmi2/model_description.rs
+++ b/fmi-schema/src/fmi2/model_description.rs
@@ -57,8 +57,9 @@ pub struct Fmi2ModelDescription {
     #[xml(attr = "variableNamingConvention")]
     pub variable_naming_convention: Option<String>,
 
+    /// FMI 2.0: Required for ModelExchange, ignored for Co-Simulation (may be absent).
     #[xml(attr = "numberOfEventIndicators")]
-    pub number_of_event_indicators: u32,
+    pub number_of_event_indicators: Option<u32>,
 
     /// If present, the FMU is based on FMI for Model Exchange
     #[xml(child = "ModelExchange")]
@@ -99,7 +100,7 @@ impl Fmi2ModelDescription {
     }
 
     pub fn num_event_indicators(&self) -> usize {
-        self.number_of_event_indicators as usize
+        self.number_of_event_indicators.unwrap_or(0) as usize
     }
 
     /// Get a iterator of the SalarVariables
@@ -408,7 +409,7 @@ mod tests {
         assert_eq!(md.version.as_deref(), Some("1.0"));
         // assert_eq!(x.generation_date_and_time, chrono::DateTime<chrono::Utc>::from)
         assert_eq!(md.variable_naming_convention, Some("structured".to_owned()));
-        assert_eq!(md.number_of_event_indicators, 2);
+        assert_eq!(md.number_of_event_indicators, Some(2));
         assert_eq!(md.model_variables.variables.len(), 4);
 
         let outputs = &md.model_structure.outputs.unknowns;

--- a/fmi-schema/tests/test_fmi2.rs
+++ b/fmi-schema/tests/test_fmi2.rs
@@ -24,7 +24,7 @@ fn test_fmi2() {
         )
     );
     assert_eq!(md.guid, "{8c4e810f-3df3-4a00-8276-176fa3c9f003}");
-    assert_eq!(md.number_of_event_indicators, 1);
+    assert_eq!(md.number_of_event_indicators, Some(1));
 
     let me = md.model_exchange.unwrap();
     assert_eq!(me.model_identifier(), "BouncingBall");
@@ -66,4 +66,24 @@ fn test_fmi2() {
     assert_eq!(typedefs.types.len(), 3);
     assert_eq!(typedefs.types[0].name, "Position");
     assert!(matches!(typedefs.types[0].elem, SimpleTypeElement::Real(_)));
+}
+
+#[test]
+#[cfg(feature = "fmi2")]
+fn test_fmi2_co_simulation_without_event_indicators() {
+    use std::str::FromStr;
+
+    let xml = r#"
+<fmiModelDescription fmiVersion="2.0" modelName="CsOnly" guid="{00000000-0000-0000-0000-000000000000}">
+    <CoSimulation modelIdentifier="CsOnly" />
+    <ModelVariables />
+    <ModelStructure />
+</fmiModelDescription>
+"#;
+
+    let md = fmi_schema::fmi2::Fmi2ModelDescription::from_str(xml).unwrap();
+    assert!(md.model_exchange.is_none());
+    assert!(md.co_simulation.is_some());
+    assert_eq!(md.number_of_event_indicators, None);
+    assert_eq!(md.num_event_indicators(), 0);
 }


### PR DESCRIPTION
Fixes #143 