### PR TITLE
fix(fmi-schema): ignore unknown FMI2 top-level elements

### DIFF
--- a/fmi-schema/src/fmi2/model_description.rs
+++ b/fmi-schema/src/fmi2/model_description.rs
@@ -5,10 +5,7 @@ use super::{
 };
 
 #[derive(Default, Debug, hard_xml::XmlRead, hard_xml::XmlWrite)]
-#[xml(
-    tag = "fmiModelDescription",
-    strict(unknown_attribute, unknown_element)
-)]
+#[xml(tag = "fmiModelDescription", strict(unknown_attribute))]
 pub struct Fmi2ModelDescription {
     /// Version of FMI (Clarification for FMI 2.0.2: for FMI 2.0.x revisions fmiVersion is defined
     /// as "2.0").

--- a/fmi-schema/tests/test_fmi2.rs
+++ b/fmi-schema/tests/test_fmi2.rs
@@ -87,3 +87,26 @@ fn test_fmi2_co_simulation_without_event_indicators() {
     assert_eq!(md.number_of_event_indicators, None);
     assert_eq!(md.num_event_indicators(), 0);
 }
+
+#[test]
+#[cfg(feature = "fmi2")]
+fn test_fmi2_with_vendor_annotations() {
+    use std::str::FromStr;
+
+    let xml = r#"
+<fmiModelDescription fmiVersion="2.0" modelName="VendorAnnotated" guid="{11111111-1111-1111-1111-111111111111}">
+    <CoSimulation modelIdentifier="VendorAnnotated" />
+    <VendorAnnotations>
+        <Tool name="Simulink">
+            <SomeToolSpecificMetadata key="value" />
+        </Tool>
+    </VendorAnnotations>
+    <ModelVariables />
+    <ModelStructure />
+</fmiModelDescription>
+"#;
+
+    let md = fmi_schema::fmi2::Fmi2ModelDescription::from_str(xml).unwrap();
+    assert_eq!(md.model_name, "VendorAnnotated");
+    assert!(md.co_simulation.is_some());
+}


### PR DESCRIPTION
## Summary
- allow parsing FMI 2.0 modelDescription XML with extra top-level metadata elements
- keep strict handling for unknown attributes
- add regression test for `VendorAnnotations` payloads from Simulink-generated FMUs

Fixes #173