### PR TITLE
fix(fmi-schema): Make description attribute of log categories optional

### DIFF
--- a/fmi-schema/src/fmi2/model_description.rs
+++ b/fmi-schema/src/fmi2/model_description.rs
@@ -271,7 +271,7 @@ pub struct Category {
     #[xml(attr = "name")]
     pub name: String,
     #[xml(attr = "description")]
-    pub description: String,
+    pub description: Option<String>,
 }
 
 #[derive(Clone, Default, PartialEq, Debug, hard_xml::XmlRead, hard_xml::XmlWrite)]


### PR DESCRIPTION
FMI 2.0 specification (version 2.0.5) states in section 2.2.4:

> The optional attribute description shall contain a description of the respective log category.

Comply with it and make the description attribute optional