### PR TITLE
fmi2: Map Linux/aarch64 to binaries/linux64/ platform folder

### DIFF
--- a/fmi/src/fmi2/import.rs
+++ b/fmi/src/fmi2/import.rs
@@ -39,6 +39,9 @@ impl FmiImport for Fmi2Import {
             ("windows", "x86") => "win32",
             ("linux", "x86_64") => "linux64",
             ("linux", "x86") => "linux32",
+            // FMI 2.0 predates Linux/aarch64; FMpy and other common exporters place aarch64
+            // binaries under binaries/linux64/ by convention, so map to "linux64" here.
+            ("linux", "aarch64") => "linux64",
             ("macos", "x86_64") => "darwin64",
             ("macos", "x86") => "darwin32",
             _ => {


### PR DESCRIPTION
FMI 2.0 was written before Linux/aarch64 became widespread and defines no architecture-specific platform folder for it. Common FMU exporters use linux64 for all 64-bit Linux platforms regardless of CPU architecture:

- OpenModelica: verified by exporting an FMU in a linux/arm64 container — the shared library lands in binaries/linux64/, not a separate aarch64 path.
- FMpy: explicitly maps Linux/aarch64 to linux64 in its platform detection.

Map ("linux", "aarch64") to "linux64" so rust-fmi can load FMUs produced by these tools on Linux/aarch64.